### PR TITLE
Crude 1.18 support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
+/build
 .git

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,11 +8,10 @@ ENV DEBIAN_FRONTEND noninteractive
 # Get dependencies
 RUN apt-get update && apt-get install -y libpng-dev libjpeg-turbo8 libboost-iostreams-dev git cmake build-essential libboost-all-dev libjpeg-dev
 
-# Add the git repo and build it
-RUN mkdir /git && cd /git && \
-    git clone --single-branch --branch world117 -n https://github.com/Dinip/mapcrafter.git && \
-    cd mapcrafter/ && git checkout \
-    && mkdir build && cd build && \
+ADD . /src/mapcrafter
+WORKDIR /src/mapcrafter
+
+RUN mkdir build && cd build && \
     cmake .. && \
     make && \
     mkdir /tmp/mapcrafter && \

--- a/bootstrap
+++ b/bootstrap
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+cat << EOF > build/render.conf
+output_dir = output
+
+[world:overworld]
+input_dir = world
+dimension = overworld
+
+[map:overworld]
+world = overworld
+name = Overworld
+render_view = isometric
+EOF
+
+ln -s ../../src/data ./build/data

--- a/src/mapcraftercore/mc/chunk.cpp
+++ b/src/mapcraftercore/mc/chunk.cpp
@@ -171,13 +171,6 @@ bool Chunk::readNBT(mc::BlockStateRegistry& block_registry, const char* data, si
 	}
 	int data_version = nbt.findTag<nbt::TagInt>("DataVersion").payload;
 
-	// find "level" tag
-	if (!nbt.hasTag<nbt::TagCompound>("Level")) {
-		LOG(ERROR) << "Corrupt chunk: No level tag found!";
-		return false;
-	}
-	const nbt::TagCompound& level = nbt.findTag<nbt::TagCompound>("Level");
-
 	// then find x/z pos of the chunk
 	if (!level.hasTag<nbt::TagInt>("xPos") || !level.hasTag<nbt::TagInt>("zPos")) {
 		LOG(ERROR) << "Corrupt chunk: No x/z position found!";

--- a/src/mapcraftercore/mc/chunk.cpp
+++ b/src/mapcraftercore/mc/chunk.cpp
@@ -218,10 +218,10 @@ bool Chunk::readNBT(mc::BlockStateRegistry& block_registry, const char* data, si
 	// find sections list
 	// ignore it if section list does not exist, can happen sometimes with the empty
 	// chunks of the end
-	if (!level.hasList<nbt::TagCompound>("Sections"))
+	if (!nbt.hasList<nbt::TagCompound>("sections"))
 		return true;
 	
-	const nbt::TagList& sections_tag = level.findTag<nbt::TagList>("Sections");
+	const nbt::TagList& sections_tag = nbt.findTag<nbt::TagList>("sections");
 	if (sections_tag.tag_type != nbt::TagCompound::TAG_TYPE)
 		return true;
 

--- a/src/mapcraftercore/mc/chunk.cpp
+++ b/src/mapcraftercore/mc/chunk.cpp
@@ -242,9 +242,14 @@ bool Chunk::readNBT(mc::BlockStateRegistry& block_registry, const char* data, si
 		//const nbt::TagByteArray& blocks = section_tag.findTag<nbt::TagByteArray>("Blocks");
 		//const nbt::TagByteArray& data = section_tag.findTag<nbt::TagByteArray>("Data");
 	
-		const nbt::TagLongArray& blockstates = section_tag.findTag<nbt::TagLongArray>("BlockStates");
+		const nbt::TagCompound& blockstates_container = section_tag.findTag<nbt::TagCompound>("block_states");
+
+		if (!blockstates_container.hasTag<nbt::TagLongArray>("data"))
+			continue;
+
+		const nbt::TagLongArray& blockstates = blockstates_container.findTag<nbt::TagLongArray>("data");
 		
-		const nbt::TagList& palette = section_tag.findTag<nbt::TagList>("Palette");
+		const nbt::TagList& palette = blockstates_container.findTag<nbt::TagList>("palette");
 		std::vector<mc::BlockState> palette_blockstates(palette.payload.size());
 		std::vector<uint16_t> palette_lookup(palette.payload.size());
 

--- a/src/mapcraftercore/mc/chunk.cpp
+++ b/src/mapcraftercore/mc/chunk.cpp
@@ -172,12 +172,12 @@ bool Chunk::readNBT(mc::BlockStateRegistry& block_registry, const char* data, si
 	int data_version = nbt.findTag<nbt::TagInt>("DataVersion").payload;
 
 	// then find x/z pos of the chunk
-	if (!level.hasTag<nbt::TagInt>("xPos") || !level.hasTag<nbt::TagInt>("zPos")) {
+	if (!nbt.hasTag<nbt::TagInt>("xPos") || !nbt.hasTag<nbt::TagInt>("zPos")) {
 		LOG(ERROR) << "Corrupt chunk: No x/z position found!";
 		return false;
 	}
-	chunkpos_original = ChunkPos(level.findTag<nbt::TagInt>("xPos").payload,
-	                             level.findTag<nbt::TagInt>("zPos").payload);
+	chunkpos_original = ChunkPos(nbt.findTag<nbt::TagInt>("xPos").payload,
+	                             nbt.findTag<nbt::TagInt>("zPos").payload);
 	chunkpos = chunkpos_original;
 	if (rotation)
 		chunkpos.rotate(rotation);

--- a/src/mapcraftercore/mc/chunk.cpp
+++ b/src/mapcraftercore/mc/chunk.cpp
@@ -195,6 +195,8 @@ bool Chunk::readNBT(mc::BlockStateRegistry& block_registry, const char* data, si
 		}
 	}
 
+	//FIXME Don't look for old Biomes tag - hardcode value for now
+	/*
 	if (level.hasArray<nbt::TagByteArray>("Biomes", BIOMES_ARRAY_SIZE)) {
 		const nbt::TagByteArray& biomes_tag = level.findTag<nbt::TagByteArray>("Biomes");
 		std::copy(biomes_tag.payload.begin(), biomes_tag.payload.end(), biomes);
@@ -210,6 +212,8 @@ bool Chunk::readNBT(mc::BlockStateRegistry& block_registry, const char* data, si
 		LOG(WARNING) << "Corrupt chunk " << chunkpos << ": No biome data found!";
 		//level.dump(std::cout);
 	}
+	*/
+	std::fill(biomes, biomes + BIOMES_ARRAY_SIZE, 21); // 21 is "Default biome" according to Chunk::clear
 
 	// find sections list
 	// ignore it if section list does not exist, can happen sometimes with the empty

--- a/src/mapcraftercore/mc/chunk.cpp
+++ b/src/mapcraftercore/mc/chunk.cpp
@@ -233,8 +233,7 @@ bool Chunk::readNBT(mc::BlockStateRegistry& block_registry, const char* data, si
 		if (!section_tag.hasTag<nbt::TagByte>("Y")
 		//		|| !section_tag.hasArray<nbt::TagByteArray>("Blocks", 4096)
 		//		|| !section_tag.hasArray<nbt::TagByteArray>("Data", 2048)
-				|| !section_tag.hasArray<nbt::TagLongArray>("BlockStates")
-				|| !section_tag.hasTag<nbt::TagList>("Palette"))
+				|| !section_tag.hasTag<nbt::TagCompound>("block_states"))
 			continue;
 		
 		const nbt::TagByte& y = section_tag.findTag<nbt::TagByte>("Y");

--- a/src/mapcraftercore/mc/chunk.cpp
+++ b/src/mapcraftercore/mc/chunk.cpp
@@ -186,8 +186,8 @@ bool Chunk::readNBT(mc::BlockStateRegistry& block_registry, const char* data, si
 	// check whether this chunk is completely contained within the cropped world
 	chunk_completely_contained = world_crop.isChunkCompletelyContained(chunkpos_original);
 
-	if (level.hasTag<nbt::TagString>("Status")) {
-		const nbt::TagString& tag = level.findTag<nbt::TagString>("Status");
+	if (nbt.hasTag<nbt::TagString>("Status")) {
+		const nbt::TagString& tag = nbt.findTag<nbt::TagString>("Status");
 		// completely generated chunks in fresh 1.13 worlds usually have status 'fullchunk' or 'postprocessed'
 		// however, chunks of converted <1.13 worlds don't use these, but the state 'mobs_spawned'
 		if (!(tag.payload == "fullchunk" || tag.payload == "full" || tag.payload == "postprocessed" || tag.payload == "mobs_spawned")) {

--- a/src/mapcraftercore/mc/chunk.h
+++ b/src/mapcraftercore/mc/chunk.h
@@ -33,13 +33,8 @@ namespace mc {
 class BlockStateRegistry;
 
 // chunk height in sections
-/* Save for 1.18 */
-/*
 const int CHUNK_LOW = -64/16;
 const int CHUNK_TOP = 320/16;
-*/
-const int CHUNK_LOW = 0;
-const int CHUNK_TOP = 256/16;
 const int BIOMES_ARRAY_SIZE = (16/4) * (16/4) * ((CHUNK_TOP-CHUNK_LOW)*16)/4;
 
 /**


### PR DESCRIPTION
I would not advise merging this PR in its current form, but I figured a PR was a better place to talk than commit comments!

This PR notably:

* Enables Mapcrafter to run on 1.18-format chunks
* Breaks support for older-format chunks because I skipped compatibility
* Hardcodes Plains biome because I didn't implement palette support
  * b0e9220
* Includes unrelated Docker changes (#3 and 066fc3e)

But it *works* - it runs and it renders the 1.18 chunks that are there, and if your map is pure 1.18 because it's fresh or you've regenerated all older chunks then you could even not notice the issues...!

I would like to fix compatibility and implement biome palettes and present you with an actually-mergeable PR but I can't commit to if/when that will happen